### PR TITLE
Fix minor typo on keras_api_design_guidelines.md

### DIFF
--- a/keras_api_design_guidelines.md
+++ b/keras_api_design_guidelines.md
@@ -184,7 +184,7 @@ Note that Keras uses the following rules for writing docstrings:
 ### Error messages: a case study
 
 
-The following would be an very poor error message:
+The following would be a very poor error message:
 
 ```
 AssertionError: '1 != 3'


### PR DESCRIPTION
I use Keras a lot for ML projects and now seek if I can contribute to Keras. So I was reading keras_api_design_guidelines.md, and found a minor typo. It would be more proper to use "a very poor error message" instead of "an very poor error message".